### PR TITLE
SC2002: Improving shell script to pass shellcheck

### DIFF
--- a/web-app/check-warnings.sh
+++ b/web-app/check-warnings.sh
@@ -13,7 +13,7 @@ try() { "$@" &> yarn.log || die "cannot $*"; }
 rm -f yarn.log
 try make build-static
 
-if cat yarn.log | grep "Compiled with warnings"; then
+if grep "Compiled with warnings" yarn.log; then
   echo "There are warnings in the code"
   exit 1
 fi


### PR DESCRIPTION
### Objective:

To improve shell script to pass shellcheck, please check SC2002: https://www.shellcheck.net/wiki/SC2002

* Many tools also accept optional filenames, e.g. `grep -q foo file` instead of `cat file | grep -q foo`.

To fix:

```
./web-app/check-warnings.sh:16:8: note: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
```