### PR TITLE
SC2148: Add shebang for shellcheck to pass

### DIFF
--- a/web-app/tests/scripts/cleanup-env.sh
+++ b/web-app/tests/scripts/cleanup-env.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+
+# This file is part of MinIO Console Server
+# Copyright (c) 2023 MinIO, Inc.
+# # This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# # This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# # You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 add_alias() {
     for i in $(seq 1 4); do
         echo "... attempting to add alias $i"

--- a/web-app/tests/scripts/common.sh
+++ b/web-app/tests/scripts/common.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # This file is part of MinIO Console Server
-# Copyright (c) 2022 MinIO, Inc.
+# Copyright (c) 2023 MinIO, Inc.
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -10,8 +12,6 @@
 # GNU Affero General Public License for more details.
 # # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
 
 add_alias() {
     for i in $(seq 1 4); do

--- a/web-app/tests/scripts/initialize-env.sh
+++ b/web-app/tests/scripts/initialize-env.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # This file is part of MinIO Console Server
-# Copyright (c) 2022 MinIO, Inc.
+# Copyright (c) 2023 MinIO, Inc.
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/web-app/tests/scripts/operator.sh
+++ b/web-app/tests/scripts/operator.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # This file is part of MinIO Console Server
-# Copyright (c) 2022 MinIO, Inc.
+# Copyright (c) 2023 MinIO, Inc.
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/web-app/tests/scripts/permissions.sh
+++ b/web-app/tests/scripts/permissions.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # This file is part of MinIO Console Server
-# Copyright (c) 2022 MinIO, Inc.
+# Copyright (c) 2023 MinIO, Inc.
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
### Objective:

Add a shebang for shellcheck to pass

### Reason:

https://www.shellcheck.net/wiki/SC2148

### Additional changes:

1. Added `Copyright`
2. Removed extra empty lines
3. Updated year in `Copyright` message

### Fixes:

This will fix:

```sh
./web-app/tests/scripts/initialize-env.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
./web-app/tests/scripts/cleanup-env.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
./web-app/tests/scripts/permissions.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
./web-app/tests/scripts/common.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
./web-app/tests/scripts/operator.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
```