### PR TITLE
SC2155: Declare and assign separately

### DIFF
--- a/web-app/tests/scripts/cleanup-env.sh
+++ b/web-app/tests/scripts/cleanup-env.sh
@@ -57,9 +57,12 @@ remove_policies() {
 }
 
 __init__() {
-  export TIMESTAMP="$(cat web-app/tests/constants/timestamp.txt)"
-  export GOPATH=/tmp/gopath
-  export PATH=${PATH}:${GOPATH}/bin
+  TIMESTAMP="$(cat web-app/tests/constants/timestamp.txt)"
+  export TIMESTAMP
+  GOPATH=/tmp/gopath
+  export GOPATH
+  PATH=${PATH}:${GOPATH}/bin
+  export PATH
 
   wget https://dl.min.io/client/mc/release/linux-amd64/mc
   chmod +x mc

--- a/web-app/tests/scripts/initialize-env.sh
+++ b/web-app/tests/scripts/initialize-env.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 # This file is part of MinIO Console Server
-# Copyright (c) 2022 MinIO, Inc.
+# Copyright (c) 2023 MinIO, Inc.
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -16,10 +18,13 @@ export SCRIPT_DIR
 source "${SCRIPT_DIR}/common.sh"
 
 __init__() {
-  export TIMESTAMP=$(date "+%s")
+  TIMESTAMP=$(date "+%s")
+  export TIMESTAMP
   echo $TIMESTAMP > web-app/tests/constants/timestamp.txt
-  export GOPATH=/tmp/gopath
-  export PATH=${PATH}:${GOPATH}/bin
+  GOPATH=/tmp/gopath
+  export GOPATH
+  PATH=${PATH}:${GOPATH}/bin
+  export PATH
 
   ARCH="`uname -m`"
   case $ARCH in


### PR DESCRIPTION
### Objective:

To fix:

```
./web-app/tests/scripts/initialize-env.sh:19:10: warning: Declare and assign separately to avoid masking return values. [SC2155]
```

### Rationale:

https://www.shellcheck.net/wiki/SC2155