### PR TITLE
SC2154: Referenced but not assigned, very likely a typo here

### DIFF
--- a/web-app/tests/scripts/cleanup-env.sh
+++ b/web-app/tests/scripts/cleanup-env.sh
@@ -50,7 +50,7 @@ remove_policies() {
   mc admin policy remove minio users-$TIMESTAMP
   mc admin policy remove minio watch-$TIMESTAMP
   mc admin policy remove minio inspect-allowed-$TIMESTAMP
-  mc admin policy remove minio inspect-not-allowed-$TIMESTAMPmc
+  mc admin policy remove minio inspect-not-allowed-$TIMESTAMP
   mc admin policy remove minio fix-prefix-policy-ui-crash-$TIMESTAMP
   mc admin policy remove minio conditions-policy-$TIMESTAMP
   mc admin policy remove minio conditions-policy-2-$TIMESTAMP


### PR DESCRIPTION
### Objective:

Fix a typo in our policies for console tests

```
./web-app/tests/scripts/cleanup-env.sh:53:52: warning: TIMESTAMPmc is referenced but not assigned (did you mean 'TIMESTAMP'?). [SC2154]
```