### PR TITLE
Fixing path for goreleaser

### DIFF
--- a/api/configure_operator.go
+++ b/api/configure_operator.go
@@ -51,7 +51,7 @@ import (
 	"github.com/minio/operator/models"
 )
 
-//go:generate swagger generate server --target ../../console --name Operator --spec ../swagger.yml --server-package api --principal models.Principal --exclude-main
+//go:generate swagger generate server --target ../ --name Operator --spec ../swagger.yml --server-package api --principal models.Principal --exclude-main
 
 var additionalServerFlags = struct {
 	CertsDir string `long:"certs-dir" description:"path to certs directory" env:"CONSOLE_CERTS_DIR"`


### PR DESCRIPTION
### Objective:

Fix:

```
2023/03/01 20:11:00 could not evaluate base import path with target "/home/runner/work/operator/console" (with symlink resolution): lstat /home/runner/work/operator/console: no such file or directory
```