### PR TITLE
Fixing coverage test by updating go version

### DIFF
--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code
@@ -330,7 +330,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code
@@ -386,7 +386,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
 
     steps:
 
@@ -423,7 +423,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     steps:
       - name: Check out code


### PR DESCRIPTION
### Objective:

To fix coverage test:

```
change directory to gocovmerge
download golang x tools
go mod tidy compat mode
go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19
Error: Process completed with exit code 1.
```

### Tested:

https://github.com/minio/operator/actions/runs/4314052180

![image](https://user-images.githubusercontent.com/6667358/222437204-7668822e-3d20-483d-8d27-fdec37b92a66.png)

To fix: https://github.com/minio/operator/pull/1469